### PR TITLE
Cookie parsing and support for attributes

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -5,7 +5,7 @@ jackson5Version = "3.0.1"
 jacksonVersion = "2.15.4"
 testngVersion = "7.5.1"
 
-project(group: "com.inversoft", name: "restify", version: "4.2.2", licenses: ["ApacheV2_0"]) {
+project(group: "com.inversoft", name: "restify", version: "4.3.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.inversoft</groupId>
   <artifactId>restify</artifactId>
-  <version>4.2.2</version>
+  <version>4.3.0</version>
   <packaging>jar</packaging>
 
   <name>Inversoft Java 8 REST Client</name>


### PR DESCRIPTION
### Summary 
- Copy over some cookie parsing fixes from `java-http`.
- Add support for unknown cookie attributes.
- Bump the version.



### Related
- https://github.com/inversoft/restify/pull/12
- https://github.com/FusionAuth/java-http/pull/37


Cookie parsing in `java-http` 
- https://github.com/FusionAuth/java-http/blob/main/src/main/java/io/fusionauth/http/Cookie.java
- https://github.com/FusionAuth/java-http/blob/main/src/test/java/io/fusionauth/http/CookieTest.java
