### PR TITLE
Bhalsey/eng 4009/restify client retries

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -5,7 +5,7 @@ jackson5Version = "3.0.1"
 jacksonVersion = "2.15.4"
 testngVersion = "7.5.1"
 
-project(group: "com.inversoft", name: "restify", version: "4.3.0", licenses: ["ApacheV2_0"]) {
+project(group: "com.inversoft", name: "restify", version: "4.4.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.inversoft</groupId>
   <artifactId>restify</artifactId>
-  <version>4.3.0</version>
+  <version>4.4.0</version>
   <packaging>jar</packaging>
 
   <name>Inversoft Java 8 REST Client</name>

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -352,7 +352,7 @@ public class RESTClient<RS, ERS> {
       }
     }
 
-    if (retryConfiguration != null && isRetryable()) {
+    if (isRetryable()) {
       return goWithRetry(requestURL, proxy);
     }
 
@@ -707,8 +707,10 @@ public class RESTClient<RS, ERS> {
   }
 
   private long calculateDelay(int attempt) {
-    long delay = (long) (retryConfiguration.initialDelay * Math.pow(retryConfiguration.backoffMultiplier, attempt - 1));
-    return Math.min(delay, retryConfiguration.maxDelay);
+    double randomJitter = Math.random() * retryConfiguration.jitter;
+    double backoffDelay = retryConfiguration.initialDelay * Math.pow(retryConfiguration.backoffMultiplier, attempt - 1);
+    double delay = Math.min(backoffDelay, retryConfiguration.maxDelay) * (1.0 + randomJitter);
+    return (long) delay;
   }
 
   private void executeOnce(ClientResponse<RS, ERS> response, URL requestURL, Proxy proxy) {
@@ -805,26 +807,14 @@ public class RESTClient<RS, ERS> {
     }
   }
 
-  private long getRetryAfterDelay(ClientResponse<RS, ERS> response) {
-    String retryAfter = response.getHeader("retry-after");
-    if (retryAfter != null) {
-      try {
-        return Long.parseLong(retryAfter) * 1000;
-      } catch (NumberFormatException ignored) {
-      }
-    }
-
-    return 0;
-  }
-
   private ClientResponse<RS, ERS> goWithRetry(URL requestURL, Proxy proxy) {
     ClientResponse<RS, ERS> response = new ClientResponse<>();
     response.request = (bodyHandler != null) ? bodyHandler.getBodyObject() : null;
     response.method = method;
 
-    for (int attempt = 0; attempt < retryConfiguration.maxAttempts; attempt++) {
+    for (int attempt = 0; attempt <= retryConfiguration.maxRetries; attempt++) {
       if (attempt > 0) {
-        long delay = Math.max(calculateDelay(attempt), getRetryAfterDelay(response));
+        long delay = calculateDelay(attempt);
         try {
           Thread.sleep(delay);
         } catch (InterruptedException e) {
@@ -840,7 +830,7 @@ public class RESTClient<RS, ERS> {
 
       executeOnce(response, requestURL, proxy);
 
-      if (!shouldRetry(response)) {
+      if (response.wasSuccessful() || !shouldRetry(response)) {
         return response;
       }
     }
@@ -849,6 +839,10 @@ public class RESTClient<RS, ERS> {
   }
 
   private boolean isRetryable() {
+    if (retryConfiguration == null || retryConfiguration.maxRetries <= 0) {
+      return false;
+    }
+
     if (retryConfiguration.allowNonIdempotentRetries) {
       return true;
     }
@@ -867,7 +861,7 @@ public class RESTClient<RS, ERS> {
     return false;
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  //@SuppressWarnings({"unchecked", "rawtypes"})
   private boolean shouldRetry(ClientResponse<RS, ERS> response) {
     // Network/IO error
     if (response.exception != null && retryConfiguration.retryOnNetworkError) {
@@ -881,7 +875,7 @@ public class RESTClient<RS, ERS> {
 
     // Custom retry function (e.g., 409 + retryableConflict)
     if (retryConfiguration.retryFunction != null) {
-      return retryConfiguration.retryFunction.apply((ClientResponse) response);
+      return retryConfiguration.retryFunction.apply(response);
     }
 
     return false;

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -355,6 +355,7 @@ public class RESTClient<RS, ERS> {
     }
 
     if (isRetryable()) {
+      validateRetryConfig();
       return goWithRetry(requestURL, proxy);
     }
 
@@ -363,6 +364,24 @@ public class RESTClient<RS, ERS> {
     response.method = method;
     executeOnce(response, requestURL, proxy);
     return response;
+  }
+
+  private void validateRetryConfig() {
+    if (bodyHandler instanceof InputStreamBodyHandler) {
+      throw new IllegalStateException("You cannot retry a request with an InputStreamBodyHandler");
+    }
+    if (retryConfiguration.initialDelay < 0) {
+      throw new IllegalStateException("You cannot have a negative initial delay");
+    }
+    if (retryConfiguration.maxDelay < 0) {
+      throw new IllegalStateException("You cannot have a negative max delay");
+    }
+    if (retryConfiguration.jitter < 0.0 || retryConfiguration.jitter > 1.0) {
+      throw new IllegalStateException("You cannot have a jitter outside the range [0.0, 1.0]");
+    }
+    if (retryConfiguration.backoffMultiplier < 0) {
+      throw new IllegalStateException("You cannot have a negative backoff multiplier");
+    }
   }
 
   public RESTClient<RS, ERS> head() {

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -81,6 +81,8 @@ public class RESTClient<RS, ERS> {
 
   private int readTimeout = 2000;
 
+  private RetryConfiguration retryConfiguration;
+
   private boolean sniVerificationDisabled;
 
   private ResponseHandler<RS> successResponseHandler;
@@ -304,136 +306,60 @@ public class RESTClient<RS, ERS> {
       throw new IllegalStateException("You specified an error response type, you must then provide an error response handler.");
     }
 
-    ClientResponse<RS, ERS> response = new ClientResponse<>();
-    response.request = (bodyHandler != null) ? bodyHandler.getBodyObject() : null;
-    response.method = method;
+    // Build the final URL with parameters (done once, before any retry loop)
+    if (parameters.size() > 0) {
+      if (url.indexOf("?") == -1) {
+        url.append("?");
+      }
 
-    HttpURLConnection huc;
-    try {
-      if (parameters.size() > 0) {
-        if (url.indexOf("?") == -1) {
-          url.append("?");
-        }
+      for (Iterator<Entry<String, List<String>>> i = parameters.entrySet().iterator(); i.hasNext(); ) {
+        Entry<String, List<String>> entry = i.next();
 
-        for (Iterator<Entry<String, List<String>>> i = parameters.entrySet().iterator(); i.hasNext(); ) {
-          Entry<String, List<String>> entry = i.next();
-
-          for (Iterator<String> j = entry.getValue().iterator(); j.hasNext(); ) {
-            String value = j.next();
+        for (Iterator<String> j = entry.getValue().iterator(); j.hasNext(); ) {
+          String value = j.next();
+          try {
             url.append(URLEncoder.encode(entry.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(value, "UTF-8"));
-            if (j.hasNext()) {
-              url.append("&");
-            }
+          } catch (Exception e) {
+            // This won't happen with UTF-8
+            throw new IllegalStateException(e);
           }
-
-          if (i.hasNext()) {
+          if (j.hasNext()) {
             url.append("&");
           }
         }
-      }
 
-      response.url = new URL(url.toString());
-
-      Proxy proxy = Proxy.NO_PROXY;
-      if (proxyInfo != null) {
-        if (proxyInfo.host != null && proxyInfo.port != -1) {
-          proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyInfo.host, proxyInfo.port));
-        }
-
-        if (proxyInfo.username != null && proxyInfo.password != null) {
-          headers.put("Proxy-Authorization", Collections.singletonList(base64Basic(proxyInfo.username, proxyInfo.password)));
+        if (i.hasNext()) {
+          url.append("&");
         }
       }
-
-      huc = (HttpURLConnection) response.url.openConnection(proxy);
-      if (response.url.getProtocol().equalsIgnoreCase("https")) {
-        HttpsURLConnection hsuc = (HttpsURLConnection) huc;
-        if (certificate != null) {
-          if (key != null) {
-            hsuc.setSSLSocketFactory(SSLTools.getSSLServerContext(certificate, key).getSocketFactory());
-          } else {
-            hsuc.setSSLSocketFactory(SSLTools.getSSLSocketFactory(certificate));
-          }
-        }
-
-        if (sniVerificationDisabled) {
-          hsuc.setHostnameVerifier((hostname, session) -> true);
-        }
-      }
-
-      huc.setInstanceFollowRedirects(followRedirects);
-      huc.setDoOutput(bodyHandler != null);
-      huc.setConnectTimeout(connectTimeout);
-      huc.setReadTimeout(readTimeout);
-      huc.setRequestMethod(method);
-
-      if (headers.keySet().stream().noneMatch(name -> name.equalsIgnoreCase(HTTPStrings.Headers.UserAgent))) {
-        headers.put(HTTPStrings.Headers.UserAgent, Collections.singletonList(userAgent));
-      }
-
-      headers.forEach((name, values) -> values.forEach(value -> huc.addRequestProperty(name, value)));
-
-      if (headers.keySet().stream().noneMatch(name -> name.equalsIgnoreCase(HTTPStrings.Headers.Cookie)) && cookies.size() > 0) {
-        String header = cookies.stream()
-                               .map(Cookie::toRequestHeader)
-                               .collect(Collectors.joining("; "));
-        huc.addRequestProperty(HTTPStrings.Headers.Cookie, header);
-      }
-
-      if (bodyHandler != null) {
-        bodyHandler.setHeaders(huc);
-      }
-
-      huc.connect();
-
-      if (bodyHandler != null) {
-        try (OutputStream os = huc.getOutputStream()) {
-          bodyHandler.accept(os);
-          os.flush();
-        }
-      }
-    } catch (Exception e) {
-      response.status = -1;
-      response.exception = e;
-      return response;
     }
 
-    int status;
+    URL requestURL;
     try {
-      status = huc.getResponseCode();
+      requestURL = new URL(url.toString());
     } catch (Exception e) {
-      response.status = -1;
-      response.exception = e;
-      return response;
+      throw new IllegalStateException("Invalid URL [" + url + "]", e);
     }
 
-    response.setHeaders(huc.getHeaderFields());
-    response.status = status;
-
-    if (status < 200 || status > 299) {
-      if (errorResponseHandler == null) {
-        return response;
+    Proxy proxy = Proxy.NO_PROXY;
+    if (proxyInfo != null) {
+      if (proxyInfo.host != null && proxyInfo.port != -1) {
+        proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyInfo.host, proxyInfo.port));
       }
 
-      try (InputStream is = huc.getErrorStream()) {
-        response.errorResponse = errorResponseHandler.apply(is);
-      } catch (Exception e) {
-        response.exception = e;
-        return response;
-      }
-    } else {
-      if (successResponseHandler == null || method.equalsIgnoreCase(HTTPMethod.HEAD.name())) {
-        return response;
-      }
-
-      try (InputStream is = huc.getInputStream()) {
-        response.successResponse = successResponseHandler.apply(is);
-      } catch (Exception e) {
-        response.exception = e;
-        return response;
+      if (proxyInfo.username != null && proxyInfo.password != null) {
+        headers.put("Proxy-Authorization", Collections.singletonList(base64Basic(proxyInfo.username, proxyInfo.password)));
       }
     }
 
+    if (retryConfiguration != null && isRetryable()) {
+      return goWithRetry(requestURL, proxy);
+    }
+
+    ClientResponse<RS, ERS> response = new ClientResponse<>();
+    response.request = (bodyHandler != null) ? bodyHandler.getBodyObject() : null;
+    response.method = method;
+    executeOnce(response, requestURL, proxy);
     return response;
   }
 
@@ -509,6 +435,11 @@ public class RESTClient<RS, ERS> {
 
   public RESTClient<RS, ERS> readTimeout(int readTimeout) {
     this.readTimeout = readTimeout;
+    return this;
+  }
+
+  public RESTClient<RS, ERS> retry(RetryConfiguration retryConfiguration) {
+    this.retryConfiguration = retryConfiguration;
     return this;
   }
 
@@ -773,6 +704,187 @@ public class RESTClient<RS, ERS> {
     String credentials = username + ":" + password;
     Base64.Encoder encoder = Base64.getEncoder();
     return "Basic " + encoder.encodeToString(credentials.getBytes());
+  }
+
+  private long calculateDelay(int attempt) {
+    long delay = (long) (retryConfiguration.initialDelay * Math.pow(retryConfiguration.backoffMultiplier, attempt - 1));
+    return Math.min(delay, retryConfiguration.maxDelay);
+  }
+
+  private void executeOnce(ClientResponse<RS, ERS> response, URL requestURL, Proxy proxy) {
+    HttpURLConnection huc;
+    try {
+      response.url = requestURL;
+      huc = (HttpURLConnection) requestURL.openConnection(proxy);
+      if (requestURL.getProtocol().equalsIgnoreCase("https")) {
+        HttpsURLConnection hsuc = (HttpsURLConnection) huc;
+        if (certificate != null) {
+          if (key != null) {
+            hsuc.setSSLSocketFactory(SSLTools.getSSLServerContext(certificate, key).getSocketFactory());
+          } else {
+            hsuc.setSSLSocketFactory(SSLTools.getSSLSocketFactory(certificate));
+          }
+        }
+
+        if (sniVerificationDisabled) {
+          hsuc.setHostnameVerifier((hostname, session) -> true);
+        }
+      }
+
+      huc.setInstanceFollowRedirects(followRedirects);
+      huc.setDoOutput(bodyHandler != null);
+      huc.setConnectTimeout(connectTimeout);
+      huc.setReadTimeout(readTimeout);
+      huc.setRequestMethod(method);
+
+      if (headers.keySet().stream().noneMatch(name -> name.equalsIgnoreCase(HTTPStrings.Headers.UserAgent))) {
+        headers.put(HTTPStrings.Headers.UserAgent, Collections.singletonList(userAgent));
+      }
+
+      headers.forEach((name, values) -> values.forEach(value -> huc.addRequestProperty(name, value)));
+
+      if (headers.keySet().stream().noneMatch(name -> name.equalsIgnoreCase(HTTPStrings.Headers.Cookie)) && cookies.size() > 0) {
+        String header = cookies.stream()
+                               .map(Cookie::toRequestHeader)
+                               .collect(Collectors.joining("; "));
+        huc.addRequestProperty(HTTPStrings.Headers.Cookie, header);
+      }
+
+      if (bodyHandler != null) {
+        bodyHandler.setHeaders(huc);
+      }
+
+      huc.connect();
+
+      if (bodyHandler != null) {
+        try (OutputStream os = huc.getOutputStream()) {
+          bodyHandler.accept(os);
+          os.flush();
+        }
+      }
+    } catch (Exception e) {
+      response.status = -1;
+      response.exception = e;
+      return;
+    }
+
+    int status;
+    try {
+      status = huc.getResponseCode();
+    } catch (Exception e) {
+      response.status = -1;
+      response.exception = e;
+      return;
+    }
+
+    response.setHeaders(huc.getHeaderFields());
+    response.status = status;
+
+    if (status < 200 || status > 299) {
+      if (errorResponseHandler == null) {
+        return;
+      }
+
+      try (InputStream is = huc.getErrorStream()) {
+        response.errorResponse = errorResponseHandler.apply(is);
+      } catch (Exception e) {
+        response.exception = e;
+        return;
+      }
+    } else {
+      if (successResponseHandler == null || method.equalsIgnoreCase(HTTPMethod.HEAD.name())) {
+        return;
+      }
+
+      try (InputStream is = huc.getInputStream()) {
+        response.successResponse = successResponseHandler.apply(is);
+      } catch (Exception e) {
+        response.exception = e;
+        return;
+      }
+    }
+  }
+
+  private long getRetryAfterDelay(ClientResponse<RS, ERS> response) {
+    String retryAfter = response.getHeader("retry-after");
+    if (retryAfter != null) {
+      try {
+        return Long.parseLong(retryAfter) * 1000;
+      } catch (NumberFormatException ignored) {
+      }
+    }
+
+    return 0;
+  }
+
+  private ClientResponse<RS, ERS> goWithRetry(URL requestURL, Proxy proxy) {
+    ClientResponse<RS, ERS> response = new ClientResponse<>();
+    response.request = (bodyHandler != null) ? bodyHandler.getBodyObject() : null;
+    response.method = method;
+
+    for (int attempt = 0; attempt < retryConfiguration.maxAttempts; attempt++) {
+      if (attempt > 0) {
+        long delay = Math.max(calculateDelay(attempt), getRetryAfterDelay(response));
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return response;
+        }
+
+        // Reset response for next attempt
+        response = new ClientResponse<>();
+        response.request = (bodyHandler != null) ? bodyHandler.getBodyObject() : null;
+        response.method = method;
+      }
+
+      executeOnce(response, requestURL, proxy);
+
+      if (!shouldRetry(response)) {
+        return response;
+      }
+    }
+
+    return response;
+  }
+
+  private boolean isRetryable() {
+    if (retryConfiguration.allowNonIdempotentRetries) {
+      return true;
+    }
+
+    // GET, PUT, DELETE, HEAD are idempotent
+    if ("GET".equals(method) || "PUT".equals(method) || "DELETE".equals(method) || "HEAD".equals(method)) {
+      return true;
+    }
+
+    // PATCH is sent as POST with X-HTTP-Method-Override header
+    if ("POST".equals(method)) {
+      List<String> override = headers.get("X-HTTP-Method-Override");
+      return override != null && override.contains("PATCH");
+    }
+
+    return false;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private boolean shouldRetry(ClientResponse<RS, ERS> response) {
+    // Network/IO error
+    if (response.exception != null && retryConfiguration.retryOnNetworkError) {
+      return true;
+    }
+
+    // Retryable status code (429, 5xx by default)
+    if (retryConfiguration.retryableStatusCodes.contains(response.status)) {
+      return true;
+    }
+
+    // Custom retry function (e.g., 409 + retryableConflict)
+    if (retryConfiguration.retryFunction != null) {
+      return retryConfiguration.retryFunction.apply((ClientResponse) response);
+    }
+
+    return false;
   }
 
   /**

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -859,7 +859,7 @@ public class RESTClient<RS, ERS> {
     }
 
     // PATCH is sent as POST with X-HTTP-Method-Override header
-    if ("POST".equals(method)) {
+    if (retryConfiguration.patchIsIdempotent && "POST".equals(method)) {
       List<String> override = headers.get("X-HTTP-Method-Override");
       return override != null && override.contains("PATCH");
     }

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -882,7 +882,6 @@ public class RESTClient<RS, ERS> {
     return false;
   }
 
-  //@SuppressWarnings({"unchecked", "rawtypes"})
   private boolean shouldRetry(ClientResponse<RS, ERS> response) {
     // Network/IO error
     if (response.exception != null && retryConfiguration.retryOnNetworkError) {

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -19,8 +19,10 @@ import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
@@ -319,7 +321,7 @@ public class RESTClient<RS, ERS> {
           String value = j.next();
           try {
             url.append(URLEncoder.encode(entry.getKey(), "UTF-8")).append("=").append(URLEncoder.encode(value, "UTF-8"));
-          } catch (Exception e) {
+          } catch (UnsupportedEncodingException e) {
             // This won't happen with UTF-8
             throw new IllegalStateException(e);
           }
@@ -337,7 +339,7 @@ public class RESTClient<RS, ERS> {
     URL requestURL;
     try {
       requestURL = new URL(url.toString());
-    } catch (Exception e) {
+    } catch (MalformedURLException e) {
       throw new IllegalStateException("Invalid URL [" + url + "]", e);
     }
 

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -89,7 +89,7 @@ public class RESTClient<RS, ERS> {
 
   private String userAgent = "Restify (https://github.com/inversoft/restify)";
 
-  // Under no circumstances should a POST request be retried due to an exception.
+  // Do not auto retry a POST request due to an exception.
   // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6382788
   static {
     System.setProperty("sun.net.http.retryPost", "false");

--- a/src/main/java/com/inversoft/rest/RESTClient.java
+++ b/src/main/java/com/inversoft/rest/RESTClient.java
@@ -93,6 +93,9 @@ public class RESTClient<RS, ERS> {
 
   // Do not auto retry a POST request due to an exception.
   // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6382788
+  // Restify uses sun.net.www.http.HttpClient, which will automatically retry
+  // when 0 bytes are read or an IOException is thrown. This retry happens
+  // automatically at a lower level than the RetryConfiguration.
   static {
     System.setProperty("sun.net.http.retryPost", "false");
   }

--- a/src/main/java/com/inversoft/rest/RetryConfiguration.java
+++ b/src/main/java/com/inversoft/rest/RetryConfiguration.java
@@ -56,6 +56,11 @@ public class RetryConfiguration {
   public int maxAttempts = 5;
 
   /**
+   * When true, patch calls are treated as idempotent. (This is dependent on the PATCH payload.)
+   */
+  public boolean patchIsIdempotent = true;
+
+  /**
    * An optional function that is called to determine if a response should be retried. This is called in addition to
    * the built-in checks for network errors and retryable status codes. Return true to retry the request.
    */

--- a/src/main/java/com/inversoft/rest/RetryConfiguration.java
+++ b/src/main/java/com/inversoft/rest/RetryConfiguration.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
+import com.inversoft.http.Buildable;
+
 /**
  * Configuration for automatic retry of failed HTTP requests.
  * <p>
@@ -28,7 +30,7 @@ import java.util.function.Function;
  *
  * @author FusionAuth
  */
-public class RetryConfiguration {
+public class RetryConfiguration implements Buildable<RetryConfiguration> {
   /**
    * When true, all HTTP methods including POST will be retried. Defaults to false,
    * meaning only idempotent methods (GET, PUT, DELETE, PATCH, HEAD) are retried.

--- a/src/main/java/com/inversoft/rest/RetryConfiguration.java
+++ b/src/main/java/com/inversoft/rest/RetryConfiguration.java
@@ -46,14 +46,22 @@ public class RetryConfiguration {
   public long initialDelay = 100;
 
   /**
+   * Maximum jitter multiplier to add to every delay. Used to smooth out thundering herds.
+   * Actual jitter multiplier is randomly chosen between 0.0 and this value.
+   */
+  public double jitter = 0.20;
+
+  /**
    * The maximum delay in milliseconds between retry attempts. Defaults to 30,000ms (30 seconds).
    */
   public long maxDelay = 30_000;
 
   /**
-   * The maximum number of attempts including the initial request. Defaults to 5 (1 initial + 4 retries).
+   * The maximum number of retries to do after the initial request.
+   * Setting to 0 effectively disables retries.
+   * Defaults to 4 (1 initial + 4 retries).
    */
-  public int maxAttempts = 5;
+  public int maxRetries = 4;
 
   /**
    * When true, patch calls are treated as idempotent. (This is dependent on the PATCH payload.)

--- a/src/main/java/com/inversoft/rest/RetryConfiguration.java
+++ b/src/main/java/com/inversoft/rest/RetryConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025-2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package com.inversoft.rest;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Configuration for automatic retry of failed HTTP requests.
+ * <p>
+ * By default, only idempotent methods (GET, PUT, DELETE, PATCH, HEAD) are retried.
+ * Set {@link #allowNonIdempotentRetries} to true to also retry POST requests.
+ *
+ * @author FusionAuth
+ */
+public class RetryConfiguration {
+  /**
+   * When true, all HTTP methods including POST will be retried. Defaults to false,
+   * meaning only idempotent methods (GET, PUT, DELETE, PATCH, HEAD) are retried.
+   */
+  public boolean allowNonIdempotentRetries;
+
+  /**
+   * The multiplier applied to the delay between each retry attempt. Defaults to 2.0 for exponential backoff.
+   */
+  public double backoffMultiplier = 2.0;
+
+  /**
+   * The initial delay in milliseconds before the first retry. Defaults to 100ms.
+   */
+  public long initialDelay = 100;
+
+  /**
+   * The maximum delay in milliseconds between retry attempts. Defaults to 30,000ms (30 seconds).
+   */
+  public long maxDelay = 30_000;
+
+  /**
+   * The maximum number of attempts including the initial request. Defaults to 5 (1 initial + 4 retries).
+   */
+  public int maxAttempts = 5;
+
+  /**
+   * An optional function that is called to determine if a response should be retried. This is called in addition to
+   * the built-in checks for network errors and retryable status codes. Return true to retry the request.
+   */
+  @SuppressWarnings("rawtypes")
+  public Function<ClientResponse, Boolean> retryFunction;
+
+  /**
+   * When true, requests that fail due to network errors (exceptions) will be retried. Defaults to true.
+   */
+  public boolean retryOnNetworkError = true;
+
+  /**
+   * The set of HTTP status codes that will trigger a retry. Defaults to 429, 500, 502, 503, 504.
+   */
+  public Set<Integer> retryableStatusCodes = new HashSet<>(Arrays.asList(429, 500, 502, 503, 504));
+}

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.testng.annotations.AfterTest;
@@ -871,6 +872,68 @@ public class RESTClientTest {
   }
 
   @Test
+  public void retry_rejects_input_stream_body_handler() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig,
+        client -> client.bodyHandler(new InputStreamBodyHandler("application/octet-stream",
+                new ByteArrayInputStream("Testing 123".getBytes(StandardCharsets.UTF_8))))
+            .put());
+
+    assertEquals(exception.getMessage(), "You cannot retry a request with an InputStreamBodyHandler");
+  }
+
+  @Test
+  public void retry_rejects_negative_initial_delay() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = -1;
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig, RESTClient::get);
+
+    assertEquals(exception.getMessage(), "You cannot have a negative initial delay");
+  }
+
+  @Test
+  public void retry_rejects_negative_max_delay() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.maxDelay = -1;
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig, RESTClient::get);
+
+    assertEquals(exception.getMessage(), "You cannot have a negative max delay");
+  }
+
+  @Test
+  public void retry_rejects_negative_jitter() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.jitter = -0.01;
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig, RESTClient::get);
+
+    assertEquals(exception.getMessage(), "You cannot have a jitter outside the range [0.0, 1.0]");
+  }
+
+  @Test
+  public void retry_rejects_jitter_greater_than_one() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.jitter = 1.01;
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig, RESTClient::get);
+
+    assertEquals(exception.getMessage(), "You cannot have a jitter outside the range [0.0, 1.0]");
+  }
+
+  @Test
+  public void retry_rejects_negative_backoff_multiplier() {
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.backoffMultiplier = -1.0;
+
+    IllegalStateException exception = expectRetryValidationFailure(retryConfig, RESTClient::get);
+
+    assertEquals(exception.getMessage(), "You cannot have a negative backoff multiplier");
+  }
+
+  @Test
   public void retry_no_retry_without_configuration() {
     handler.handleSequence("GET", new int[]{500, 200}, new String[]{null, null}, null);
 
@@ -941,6 +1004,23 @@ public class RESTClientTest {
         fail("Expected exception [" + expected + "], but caught [" + e.getClass() + "].", e);
       }
       return null;
+    }
+  }
+
+  private IllegalStateException expectRetryValidationFailure(RetryConfiguration retryConfiguration, Consumer<RESTClient<Void, Void>> clientCustomizer) {
+    try {
+      RESTClient<Void, Void> client = new RESTClient<>(Void.TYPE, Void.TYPE)
+          .url("http://localhost:7042/test")
+          .retry(retryConfiguration);
+
+      clientCustomizer.accept(client);
+      client.go();
+
+      fail("Expected retry configuration validation to fail");
+      return null;
+    } catch (IllegalStateException e) {
+      assertEquals(handler.count, 0);
+      return e;
     }
   }
 

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -673,7 +673,7 @@ public class RESTClientTest {
 
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.initialDelay = 10;
-    retryConfig.maxAttempts = 3;
+    retryConfig.maxRetries = 2;
 
     ClientResponse<Void, Void> response = new RESTClient<>(Void.TYPE, Void.TYPE)
         .url("http://localhost:7042/test")
@@ -722,7 +722,8 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_patch_is_retried() {
+  public void retry_patch_is_retried_by_default() {
+    // Default RetryConfiguration.patchIsIdempotent is true, should be retried
     handler.handleSequence("POST", new int[]{500, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
 
     RetryConfiguration retryConfig = new RetryConfiguration();
@@ -739,6 +740,28 @@ public class RESTClientTest {
     assertEquals(handler.count, 2);
     assertEquals(response.status, 200);
     assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_patch_is_not_retried_when_not_idempotent() {
+    // set RetryConfiguration.patchIsIdempotent to false, should not be retried
+    handler.handleSequence("POST", new int[]{500, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.patchIsIdempotent = false;
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .patch()
+        .go();
+
+    assertEquals(handler.count, 1);
+    assertEquals(response.status, 500);
+    assertFalse(response.wasSuccessful());
   }
 
   @Test
@@ -884,28 +907,6 @@ public class RESTClientTest {
     assertTrue(response.url.toString().contains("baz=qux"));
   }
 
-  @Test
-  public void retry_respects_retry_after_header() {
-    handler.handleRetryAfter("GET", 429, 200, "{\"code\": 200}", "application/json", "1");
-
-    RetryConfiguration retryConfig = new RetryConfiguration();
-    retryConfig.initialDelay = 10;
-
-    long start = System.currentTimeMillis();
-    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
-        .url("http://localhost:7042/test")
-        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
-        .successResponseHandler(new JSONResponseHandler<>(Map.class))
-        .retry(retryConfig)
-        .get()
-        .go();
-    long elapsed = System.currentTimeMillis() - start;
-
-    assertEquals(handler.count, 2);
-    assertEquals(response.status, 200);
-    // Retry-After: 1 second should cause at least ~1000ms delay
-    assertTrue(elapsed >= 900, "Expected at least ~1000ms delay for Retry-After, but was " + elapsed + "ms");
-  }
 
   private <T, U> ClientResponse<T, U> expectException(Supplier<ClientResponse<T, U>> supplier, Class<? extends Throwable> expected) {
     try {
@@ -942,8 +943,6 @@ public class RESTClientTest {
 
     private String[] responses;
 
-    private String retryAfterValue;
-
     public TestHandler() {
     }
 
@@ -958,7 +957,6 @@ public class RESTClientTest {
       this.cookie = cookie;
       this.responseCodes = null;
       this.responses = null;
-      this.retryAfterValue = null;
     }
 
     public void handleSequence(String method, int[] responseCodes, String[] responses, String responseContentType) {
@@ -966,19 +964,6 @@ public class RESTClientTest {
       this.responseCodes = responseCodes;
       this.responses = responses;
       this.responseContentType = responseContentType;
-      this.request = null;
-      this.contentType = null;
-      this.requestHeaders = null;
-      this.cookie = null;
-      this.retryAfterValue = null;
-    }
-
-    public void handleRetryAfter(String method, int firstCode, int secondCode, String secondResponse, String responseContentType, String retryAfterValue) {
-      this.method = method;
-      this.responseCodes = new int[]{firstCode, secondCode};
-      this.responses = new String[]{null, secondResponse};
-      this.responseContentType = responseContentType;
-      this.retryAfterValue = retryAfterValue;
       this.request = null;
       this.contentType = null;
       this.requestHeaders = null;
@@ -1057,11 +1042,6 @@ public class RESTClientTest {
         httpExchange.getResponseHeaders().set("Content-Type", responseContentType);
       }
 
-      // Add Retry-After header if configured and this is the first request
-      if (retryAfterValue != null && count == 0) {
-        httpExchange.getResponseHeaders().set("Retry-After", retryAfterValue);
-      }
-
       httpExchange.getResponseHeaders().set(HTTPStrings.Headers.SetCookie, "foo=bar; Path=/foo/bar; Domain=fusionauth.io; Max-Age=1; Secure; HttpOnly; SameSite=Lax");
       httpExchange.getResponseHeaders().set("Connection", "close");
       httpExchange.sendResponseHeaders(currentResponseCode, contentLength);
@@ -1088,7 +1068,6 @@ public class RESTClientTest {
       responseContentType = null;
       responseCodes = null;
       responses = null;
-      retryAfterValue = null;
       count = 0;
     }
   }

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.testng.annotations.AfterTest;
@@ -843,6 +844,30 @@ public class RESTClientTest {
     assertEquals(handler.count, 2);
     assertEquals(response.status, 200);
     assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_custom_retry_function_not_called_on_success() {
+    handler.handleSequence("GET", new int[]{200}, new String[]{"{\"code\": 200}"}, "application/json");
+
+    AtomicInteger retryFunctionInvocationCount = new AtomicInteger(0);
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+    retryConfig.retryFunction = response -> { retryFunctionInvocationCount.incrementAndGet(); return false;};
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 1);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+    // Retry function should not be called
+    assertEquals(retryFunctionInvocationCount.get(), 0);
   }
 
   @Test

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -990,9 +990,12 @@ public class RESTClientTest {
     assertEquals(handler.count, 2);
     assertEquals(response.status, 200);
     assertTrue(response.wasSuccessful());
-    // Verify URL parameters are not duplicated on retry
-    assertTrue(response.url.toString().contains("foo=bar"));
-    assertTrue(response.url.toString().contains("baz=qux"));
+    String url = response.url.toString();
+    // Verify URL parameters are present and not duplicated on retry
+    assertTrue(url.contains("foo=bar"));
+    assertEquals(url.indexOf("foo=bar"), url.lastIndexOf("foo=bar"));
+    assertTrue(url.contains("baz=qux"));
+    assertEquals(url.indexOf("baz=qux"), url.lastIndexOf("baz=qux"));
   }
 
 

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -646,6 +646,267 @@ public class RESTClientTest {
     assertEquals(response.successResponse, "Testing 123");
   }
 
+  @Test
+  public void retry_get_succeeds_after_500() {
+    handler.handleSequence("GET", new int[]{500, 500, 200}, new String[]{"{\"error\": true}", "{\"error\": true}", "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 3);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+    assertEquals(response.successResponse.get("code"), 200);
+  }
+
+  @Test
+  public void retry_get_exhausts_max_attempts() {
+    handler.handleSequence("GET", new int[]{500, 500, 500, 500, 500}, new String[]{null, null, null, null, null}, null);
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+    retryConfig.maxAttempts = 3;
+
+    ClientResponse<Void, Void> response = new RESTClient<>(Void.TYPE, Void.TYPE)
+        .url("http://localhost:7042/test")
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 3);
+    assertEquals(response.status, 500);
+    assertFalse(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_post_not_retried() {
+    handler.handleSequence("POST", new int[]{500, 200}, new String[]{null, null}, null);
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Void, Void> response = new RESTClient<>(Void.TYPE, Void.TYPE)
+        .url("http://localhost:7042/test")
+        .retry(retryConfig)
+        .post()
+        .go();
+
+    assertEquals(handler.count, 1);
+    assertEquals(response.status, 500);
+  }
+
+  @Test
+  public void retry_post_retried_when_allowed() {
+    handler.handleSequence("POST", new int[]{500, 200}, new String[]{null, null}, null);
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+    retryConfig.allowNonIdempotentRetries = true;
+
+    ClientResponse<Void, Void> response = new RESTClient<>(Void.TYPE, Void.TYPE)
+        .url("http://localhost:7042/test")
+        .retry(retryConfig)
+        .post()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+  }
+
+  @Test
+  public void retry_patch_is_retried() {
+    handler.handleSequence("POST", new int[]{500, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .patch()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_put_succeeds_after_429() {
+    handler.handleSequence("PUT", new int[]{429, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .put()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_delete_succeeds_after_502() {
+    handler.handleSequence("DELETE", new int[]{502, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .delete()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_not_triggered_on_400() {
+    handler.handleSequence("GET", new int[]{400, 200}, new String[]{"{\"error\": true}", "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 1);
+    assertEquals(response.status, 400);
+    assertFalse(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_custom_retry_function() {
+    handler.handleSequence("GET", new int[]{409, 200}, new String[]{"{\"retryable\": true}", "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+    retryConfig.retryFunction = response -> response.status == 409;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+  }
+
+  @Test
+  public void retry_no_retry_without_configuration() {
+    handler.handleSequence("GET", new int[]{500, 200}, new String[]{null, null}, null);
+
+    ClientResponse<Void, Void> response = new RESTClient<>(Void.TYPE, Void.TYPE)
+        .url("http://localhost:7042/test")
+        .get()
+        .go();
+
+    assertEquals(handler.count, 1);
+    assertEquals(response.status, 500);
+  }
+
+  @Test
+  public void retry_exponential_backoff() {
+    handler.handleSequence("GET", new int[]{500, 500, 200}, new String[]{null, null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 50;
+    retryConfig.backoffMultiplier = 2.0;
+
+    long start = System.currentTimeMillis();
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertEquals(handler.count, 3);
+    assertEquals(response.status, 200);
+    // First retry delay: 50ms, second retry delay: 100ms = 150ms minimum
+    assertTrue(elapsed >= 140, "Expected at least ~150ms delay, but was " + elapsed + "ms");
+  }
+
+  @Test
+  public void retry_with_url_parameters() {
+    handler.handleSequence("GET", new int[]{500, 200}, new String[]{null, "{\"code\": 200}"}, "application/json");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .urlParameter("foo", "bar")
+        .urlParameter("baz", "qux")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    assertTrue(response.wasSuccessful());
+    // Verify URL parameters are not duplicated on retry
+    assertTrue(response.url.toString().contains("foo=bar"));
+    assertTrue(response.url.toString().contains("baz=qux"));
+  }
+
+  @Test
+  public void retry_respects_retry_after_header() {
+    handler.handleRetryAfter("GET", 429, 200, "{\"code\": 200}", "application/json", "1");
+
+    RetryConfiguration retryConfig = new RetryConfiguration();
+    retryConfig.initialDelay = 10;
+
+    long start = System.currentTimeMillis();
+    ClientResponse<Map, Map> response = new RESTClient<>(Map.class, Map.class)
+        .url("http://localhost:7042/test")
+        .errorResponseHandler(new JSONResponseHandler<>(Map.class))
+        .successResponseHandler(new JSONResponseHandler<>(Map.class))
+        .retry(retryConfig)
+        .get()
+        .go();
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertEquals(handler.count, 2);
+    assertEquals(response.status, 200);
+    // Retry-After: 1 second should cause at least ~1000ms delay
+    assertTrue(elapsed >= 900, "Expected at least ~1000ms delay for Retry-After, but was " + elapsed + "ms");
+  }
+
   private <T, U> ClientResponse<T, U> expectException(Supplier<ClientResponse<T, U>> supplier, Class<? extends Throwable> expected) {
     try {
       return supplier.get();
@@ -676,6 +937,13 @@ public class RESTClientTest {
 
     private String responseContentType;
 
+    // Sequence mode fields for retry testing
+    private int[] responseCodes;
+
+    private String[] responses;
+
+    private String retryAfterValue;
+
     public TestHandler() {
     }
 
@@ -688,13 +956,52 @@ public class RESTClientTest {
       this.response = response;
       this.responseContentType = responseContentType;
       this.cookie = cookie;
+      this.responseCodes = null;
+      this.responses = null;
+      this.retryAfterValue = null;
+    }
+
+    public void handleSequence(String method, int[] responseCodes, String[] responses, String responseContentType) {
+      this.method = method;
+      this.responseCodes = responseCodes;
+      this.responses = responses;
+      this.responseContentType = responseContentType;
+      this.request = null;
+      this.contentType = null;
+      this.requestHeaders = null;
+      this.cookie = null;
+      this.retryAfterValue = null;
+    }
+
+    public void handleRetryAfter(String method, int firstCode, int secondCode, String secondResponse, String responseContentType, String retryAfterValue) {
+      this.method = method;
+      this.responseCodes = new int[]{firstCode, secondCode};
+      this.responses = new String[]{null, secondResponse};
+      this.responseContentType = responseContentType;
+      this.retryAfterValue = retryAfterValue;
+      this.request = null;
+      this.contentType = null;
+      this.requestHeaders = null;
+      this.cookie = null;
     }
 
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
+      int currentResponseCode;
+      String currentResponse;
+      if (responseCodes != null) {
+        // Sequence mode for retry testing
+        int index = Math.min(count, responseCodes.length - 1);
+        currentResponseCode = responseCodes[index];
+        currentResponse = responses[index];
+      } else {
+        currentResponseCode = responseCode;
+        currentResponse = response;
+      }
+
       if (contentType != null) {
         assertEquals(httpExchange.getRequestHeaders().get(HTTPStrings.Headers.ContentType).get(0), contentType);
-      } else {
+      } else if (responseCodes == null) {
         assertNull(httpExchange.getRequestHeaders().get(HTTPStrings.Headers.ContentType));
       }
 
@@ -731,13 +1038,13 @@ public class RESTClientTest {
 
       if (request != null) {
         assertEquals(body.toString(), request);
-      } else {
+      } else if (responseCodes == null) {
         assertTrue(body.toString().isEmpty(), "Body is [" + body + "]");
       }
 
       // Handle response
 
-      byte[] bytes = response != null ? response.getBytes(StandardCharsets.UTF_8) : null;
+      byte[] bytes = currentResponse != null ? currentResponse.getBytes(StandardCharsets.UTF_8) : null;
       int contentLength = bytes != null ? bytes.length : 0;
       if (method.equals("HEAD")) {
         // Setting to -1 will remove a warning when calling sendResponseHeaders for a HEAD request.
@@ -750,9 +1057,14 @@ public class RESTClientTest {
         httpExchange.getResponseHeaders().set("Content-Type", responseContentType);
       }
 
+      // Add Retry-After header if configured and this is the first request
+      if (retryAfterValue != null && count == 0) {
+        httpExchange.getResponseHeaders().set("Retry-After", retryAfterValue);
+      }
+
       httpExchange.getResponseHeaders().set(HTTPStrings.Headers.SetCookie, "foo=bar; Path=/foo/bar; Domain=fusionauth.io; Max-Age=1; Secure; HttpOnly; SameSite=Lax");
       httpExchange.getResponseHeaders().set("Connection", "close");
-      httpExchange.sendResponseHeaders(responseCode, contentLength);
+      httpExchange.sendResponseHeaders(currentResponseCode, contentLength);
 
       if (!method.equals("HEAD")) {
         if (bytes != null) {
@@ -770,9 +1082,13 @@ public class RESTClientTest {
       cookie = null;
       method = null;
       request = null;
+      requestHeaders = null;
       response = null;
       responseCode = 0;
       responseContentType = null;
+      responseCodes = null;
+      responses = null;
+      retryAfterValue = null;
       count = 0;
     }
   }

--- a/src/test/java/com/inversoft/rest/RESTClientTest.java
+++ b/src/test/java/com/inversoft/rest/RESTClientTest.java
@@ -872,7 +872,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_input_stream_body_handler() {
+  public void validate_retry_input_stream_body_handler() {
     RetryConfiguration retryConfig = new RetryConfiguration();
 
     IllegalStateException exception = expectRetryValidationFailure(retryConfig,
@@ -884,7 +884,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_negative_initial_delay() {
+  public void validate_retry_negative_initial_delay() {
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.initialDelay = -1;
 
@@ -894,7 +894,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_negative_max_delay() {
+  public void validate_retry_negative_max_delay() {
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.maxDelay = -1;
 
@@ -904,7 +904,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_negative_jitter() {
+  public void validate_retry_negative_jitter() {
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.jitter = -0.01;
 
@@ -914,7 +914,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_jitter_greater_than_one() {
+  public void validate_retry_jitter_greater_than_one() {
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.jitter = 1.01;
 
@@ -924,7 +924,7 @@ public class RESTClientTest {
   }
 
   @Test
-  public void retry_rejects_negative_backoff_multiplier() {
+  public void validate_retry_negative_backoff_multiplier() {
     RetryConfiguration retryConfig = new RetryConfiguration();
     retryConfig.backoffMultiplier = -1.0;
 


### PR DESCRIPTION
### Issue:

- https://linear.app/fusionauth/issue/ENG-4009/add-retry-handling-in-java-fusionauthclient

### Problem:

FusionAuthClient doesn't offer a configurable retry policy.

### Solution:

Add configurable retries in restify so FusionAuthClient can use it.

### Linked PR:

- https://github.com/fusionauth-eng/fusionauth-app/pull/1369

### Reviewer Notes:

Additional testing done in fusionauth-load-tests.

