### PR TITLE
Remove duplicate test run

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -94,7 +94,8 @@ target(name: "pom", description: "Updates the pom.xml file") {
 }
 
 target(name: "publish", description: "Publish to MVN repo", dependsOn: ["clean", "test"]) {
-  if (new ProcessBuilder('mvn', 'clean', 'deploy', '-Prelease').inheritIO().start().waitFor() != 0) {
+  // no need to have Maven run tests because Savant just ran them
+  if (new ProcessBuilder('mvn', 'clean', 'deploy', '-Prelease', '-DskipTests').inheritIO().start().waitFor() != 0) {
     fail("deploy failed")
   }
 }


### PR DESCRIPTION
For some reason, `mvn test` failed. Removing that when we publish, considering we already run `sb test`

Problematic build - https://github.com/inversoft/restify/actions/runs/25181393513
"Fixed" build - https://github.com/inversoft/restify/actions/runs/25181630201/job/73828077666